### PR TITLE
slurp-28 Catch extraction exception and abort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,14 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd
 ## PHP dependencies
-RUN docker-php-ext-install \
+RUN docker-php-ext-install -j$(nproc) \
         pdo \
         pdo_mysql \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
 # composer
-RUN curl -sS https://getcomposer.org/installer | php && \
-	  mv composer.phar /usr/local/bin/composer
+RUN curl -sS https://getcomposer.org/installer | php \
+	  && mv composer.phar /usr/local/bin/composer \
+	  && apt-get install git unzip
 ENV COMPOSER_ALLOW_SUPERUSER=1
 WORKDIR /src

--- a/src/Event/ExtractionAbortedEvent.php
+++ b/src/Event/ExtractionAbortedEvent.php
@@ -14,4 +14,36 @@ use Symfony\Component\EventDispatcher\Event;
 class ExtractionAbortedEvent extends Event
 {
     public const NAME = 'slurp.extraction.aborted';
+
+    /**
+     * @var string|null
+     */
+    private $reason;
+
+    /**
+     * @var int|null
+     */
+    private $recordId;
+
+    public function __construct(string $reason = null, int $recordId = null)
+    {
+        $this->reason = $reason;
+        $this->recordId = $recordId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getRecordId(): ?int
+    {
+        return $this->recordId;
+    }
 }

--- a/src/Exception/PipelineException.php
+++ b/src/Exception/PipelineException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Author: Courtney Miles
+ * Date: 17/8/19
+ * Time: 10:48 am
+ */
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Exception;
+
+class PipelineException extends \Exception implements ExceptionInterface
+{
+}

--- a/src/Extract/Exception/ExtractionException.php
+++ b/src/Extract/Exception/ExtractionException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Author: Courtney Miles
+ * Date: 17/8/19
+ * Time: 9:43 am
+ */
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\Exception;
+
+use Exception;
+use MilesAsylum\Slurp\Exception\ExceptionInterface;
+
+class ExtractionException extends Exception implements ExceptionInterface
+{
+}

--- a/src/Extract/Exception/MalformedSourceException.php
+++ b/src/Extract/Exception/MalformedSourceException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Author: Courtney Miles
+ * Date: 18/8/19
+ * Time: 10:46 am
+ */
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\Exception;
+
+class MalformedSourceException extends ExtractionException
+{
+}

--- a/src/Extract/Exception/ValueCountMismatchException.php
+++ b/src/Extract/Exception/ValueCountMismatchException.php
@@ -9,10 +9,7 @@ declare(strict_types=1);
 
 namespace MilesAsylum\Slurp\Extract\Exception;
 
-use Exception;
-use MilesAsylum\Slurp\Exception\ExceptionInterface;
-
-class ValueCountMismatchException extends Exception implements ExceptionInterface
+class ValueCountMismatchException extends MalformedSourceException
 {
     public static function createMismatch($recordId, int $givenValueCount, int $expectedValueCount): self
     {

--- a/src/OuterPipeline/Exception/OuterPipelineException.php
+++ b/src/OuterPipeline/Exception/OuterPipelineException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Author: Courtney Miles
+ * Date: 17/8/19
+ * Time: 10:48 am
+ */
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\OuterPipeline\Exception;
+
+use MilesAsylum\Slurp\Exception\PipelineException;
+
+class OuterPipelineException extends PipelineException
+{
+}

--- a/tests/Slurp/Event/ExtractionAbortedEventTest.php
+++ b/tests/Slurp/Event/ExtractionAbortedEventTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Author: Courtney Miles
+ * Date: 17/8/19
+ * Time: 5:00 pm
+ */
+
+namespace MilesAsylum\Slurp\Tests\Slurp\Event;
+
+use MilesAsylum\Slurp\Event\ExtractionAbortedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ExtractionAbortedEventTest extends TestCase
+{
+    public function testDefaultReason(): void
+    {
+        $event = new ExtractionAbortedEvent();
+
+        $this->assertNull($event->getReason());
+    }
+
+    public function testDefaultRecordId(): void
+    {
+        $event = new ExtractionAbortedEvent();
+
+        $this->assertNull($event->getRecordId());
+    }
+
+    public function testGetReason(): void
+    {
+        $reason = 'foo';
+        $event = new ExtractionAbortedEvent($reason);
+
+        $this->assertSame($reason, $event->getReason());
+    }
+
+    public function testGetRecordId(): void
+    {
+        $recordId = 123;
+        $event = new ExtractionAbortedEvent(null, $recordId);
+
+        $this->assertSame($recordId, $event->getRecordId());
+    }
+}


### PR DESCRIPTION
#28 

This PR has the Slurp process catch an exception raised by the extractor due to malformed source data. It then marks the slurp process as aborted and dispatches an Extraction Aborted Event.