### PR TITLE
Enforce unique values on extraction

### DIFF
--- a/src/Extract/CsvFileExtractor/CsvMultiFileExtractor.php
+++ b/src/Extract/CsvFileExtractor/CsvMultiFileExtractor.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace MilesAsylum\Slurp\Extract\CsvFileExtractor;
 
+use MilesAsylum\Slurp\SlurpFactory;
+
 class CsvMultiFileExtractor implements CsvFileExtractorInterface
 {
     /**
@@ -27,6 +29,10 @@ class CsvMultiFileExtractor implements CsvFileExtractorInterface
         }
     }
 
+    /**
+     * @deprecated
+     * @see SlurpFactory::createCsvMultiFileExtractor()
+     */
     public static function createFromPaths(array $paths)
     {
         $extractors = [];

--- a/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\CsvFileExtractor;
+
+use IteratorIterator;
+use MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException;
+
+class EnforcePrimaryKeyIterator extends IteratorIterator
+{
+    private $primaryKeyFieldsValues = [];
+
+    private $primaryKeyFields = [];
+
+    public function __construct(\Traversable $iterator, array $primaryKeyFields)
+    {
+        parent::__construct($iterator);
+        $this->primaryKeyFields = $primaryKeyFields;
+    }
+
+    /**
+     * @throws DuplicatePrimaryKeyValueException
+     */
+    public function current()
+    {
+        $currentRecord = parent::current();
+        $pkValues = [];
+
+        foreach ($this->primaryKeyFields as $pkField) {
+            if (!array_key_exists($pkField, $currentRecord)) {
+                throw new \InvalidArgumentException('The supplied record does not contain the primary key field ' . $pkField . '.');
+            }
+
+            $pkValues[$pkField] = $currentRecord[$pkField];
+        }
+
+        $pkValues = array_values($pkValues);
+
+        if (in_array($pkValues, $this->primaryKeyFieldsValues, false)) {
+            throw DuplicatePrimaryKeyValueException::create($this->primaryKeyFields, $pkValues, $this->key());
+        }
+
+        $this->primaryKeyFieldsValues[] = $pkValues;
+
+        return parent::current();
+    }
+}

--- a/src/Extract/CsvFileExtractor/EnforceUniqueFieldIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforceUniqueFieldIterator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\CsvFileExtractor;
+
+use IteratorIterator;
+use MilesAsylum\Slurp\Extract\Exception\DuplicateFieldValueException;
+use Traversable;
+
+class EnforceUniqueFieldIterator extends IteratorIterator
+{
+    /**
+     * @var array<string, array>
+     */
+    private $uniqueFieldValues;
+
+    public function __construct(Traversable $iterator, array $uniqueFields)
+    {
+        parent::__construct($iterator);
+
+        $this->uniqueFieldValues = array_fill_keys($uniqueFields, []);
+    }
+
+    public function current()
+    {
+        $currentRecord = parent::current();
+
+        foreach ($currentRecord as $field => $value) {
+            if (!array_key_exists($field, $this->uniqueFieldValues)) {
+                continue;
+            }
+
+            if (in_array($value, $this->uniqueFieldValues[$field], false)) {
+                throw DuplicateFieldValueException::create($field, $value, $this->key());
+            }
+
+            $this->uniqueFieldValues[$field][] = $value;
+        }
+
+        return parent::current();
+    }
+}

--- a/src/Extract/Exception/DuplicateFieldValueException.php
+++ b/src/Extract/Exception/DuplicateFieldValueException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\Exception;
+
+class DuplicateFieldValueException extends ExtractionException
+{
+    public static function create(string $field, $value, int $recordNum): self
+    {
+        return new self(
+            sprintf(
+                "Duplicate value '%s' found for field %s in record number %s.",
+                $value,
+                $field,
+                $recordNum
+            )
+        );
+    }
+}

--- a/src/Extract/Exception/DuplicatePrimaryKeyValueException.php
+++ b/src/Extract/Exception/DuplicatePrimaryKeyValueException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Extract\Exception;
+
+class DuplicatePrimaryKeyValueException extends ExtractionException
+{
+    /**
+     * @param string[] $pkFields
+     */
+    public static function create(array $pkFields, array $pkValues, int $recordNum): self
+    {
+        return new self(
+            sprintf(
+                "Duplicate value '%s' found for primary key %s in record number %s.",
+                implode(':', $pkValues),
+                implode(':', $pkFields),
+                $recordNum
+            )
+        );
+    }
+}

--- a/tests/Slurp/Extract/CsvFileExtractor/EnforcePrimaryKeyIteratorTest.php
+++ b/tests/Slurp/Extract/CsvFileExtractor/EnforcePrimaryKeyIteratorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Tests\Slurp\Extract\CsvFileExtractor;
+
+use MilesAsylum\Slurp\Extract\CsvFileExtractor\EnforcePrimaryKeyIterator;
+use MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MilesAsylum\Slurp\Extract\CsvFileExtractor\EnforcePrimaryKeyIterator
+ */
+class EnforcePrimaryKeyIteratorTest extends TestCase
+{
+    public function testValueInEqualsValueOut(): void
+    {
+        $row = ['foo' => 123, 'bar' => 'abc'];
+        $sut = new EnforcePrimaryKeyIterator(
+            new \ArrayIterator([$row]),
+            []
+        );
+        $sut->rewind();
+
+        self::assertSame($row, $sut->current());
+    }
+
+    public function testExceptionOnDuplicatePrimaryKeyValue(): void
+    {
+        $this->expectException(DuplicatePrimaryKeyValueException::class);
+        $this->expectExceptionMessage('Duplicate value \'123:abc\' found for primary key pk_1:pk_2 in record number 2.');
+
+        $rows = [
+            ['pk_1' => 123, 'pk_2' => 'abc', 'foo' => 'bar'],
+            ['pk_1' => 123, 'pk_2' => 'bce', 'foo' => 'qux'],
+            ['pk_1' => 123, 'pk_2' => 'abc', 'foo' => 'baz'],
+        ];
+        $sut = new EnforcePrimaryKeyIterator(
+            new \ArrayIterator($rows),
+            ['pk_1', 'pk_2']
+        );
+        $sut->rewind();
+
+        foreach ($sut as $record) {
+            // Do nothing
+        }
+    }
+}

--- a/tests/Slurp/Extract/CsvFileExtractor/EnforceUniqueFieldIteratorTest.php
+++ b/tests/Slurp/Extract/CsvFileExtractor/EnforceUniqueFieldIteratorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Tests\Slurp\Extract\CsvFileExtractor;
+
+use MilesAsylum\Slurp\Extract\CsvFileExtractor\EnforceUniqueFieldIterator;
+use MilesAsylum\Slurp\Extract\Exception\DuplicateFieldValueException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MilesAsylum\Slurp\Extract\CsvFileExtractor\EnforceUniqueFieldIterator
+ */
+class EnforceUniqueFieldIteratorTest extends TestCase
+{
+    public function testValueInEqualsValueOut(): void
+    {
+        $row = ['foo' => 123, 'bar' => 'abc'];
+        $sut = new EnforceUniqueFieldIterator(
+            new \ArrayIterator([$row]),
+            []
+        );
+        $sut->rewind();
+
+        self::assertSame($row, $sut->current());
+    }
+
+    public function testExceptionOnDuplicateFieldValue(): void
+    {
+        $this->expectException(DuplicateFieldValueException::class);
+        $this->expectExceptionMessage('Duplicate value \'123\' found for field foo in record number 2.');
+        $rows = [
+            ['foo' => 123, 'bar' => 'abc'],
+            ['foo' => 234, 'bar' => 'bce'],
+            ['foo' => 123, 'bar' => 'def'],
+        ];
+        $sut = new EnforceUniqueFieldIterator(
+            new \ArrayIterator($rows),
+            ['foo']
+        );
+        $sut->rewind();
+
+        foreach ($sut as $record) {
+            // Do nothing
+        }
+    }
+}

--- a/tests/Slurp/Extract/Exception/DuplicateFieldValueExceptionTest.php
+++ b/tests/Slurp/Extract/Exception/DuplicateFieldValueExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Tests\Slurp\Extract\Exception;
+
+use MilesAsylum\Slurp\Extract\Exception\DuplicateFieldValueException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MilesAsylum\Slurp\Extract\Exception\DuplicateFieldValueException
+ */
+class DuplicateFieldValueExceptionTest extends TestCase
+{
+    public function testExceptionMessage(): void
+    {
+        self::assertSame(
+            'Duplicate value \'123\' found for field foo in record number 234.',
+            DuplicateFieldValueException::create('foo', 123, 234)
+                ->getMessage()
+        );
+    }
+}

--- a/tests/Slurp/Extract/Exception/DuplicatePrimaryKeyValueExceptionTest.php
+++ b/tests/Slurp/Extract/Exception/DuplicatePrimaryKeyValueExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Slurp\Tests\Slurp\Extract\Exception;
+
+use MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException
+ */
+class DuplicatePrimaryKeyValueExceptionTest extends TestCase
+{
+    public function testExceptionMessage(): void
+    {
+        self::assertSame(
+            'Duplicate value \'123:abc\' found for primary key foo:bar in record number 234.',
+            DuplicatePrimaryKeyValueException::create(['foo', 'bar'], [123, 'abc'], 234)
+                ->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
**What:** Throws an exception if a non-unique value is encountered during extraction for field/s that a unique or the primary key.
**Why:** [frictionlessdata/tableschema-php](https://github.com/frictionlessdata/tableschema-php) enforces this during extraction of records from a CSV, but we use own strategy for extracting records from a CSV and so need to enforce this check ourselves.
**Ticket:** #48 