### PR TITLE
Issue 50 : Optimise uniqueness check

### DIFF
--- a/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
@@ -36,13 +36,27 @@ class EnforcePrimaryKeyIterator extends IteratorIterator
         }
 
         $pkValues = array_values($pkValues);
+        $normPkValues = self::normalisePrimaryKeysValue($pkValues);
 
-        if (in_array($pkValues, $this->primaryKeyFieldsValues, false)) {
+        if (isset($this->primaryKeyFieldsValues[$normPkValues])) {
             throw DuplicatePrimaryKeyValueException::create($this->primaryKeyFields, $pkValues, $this->key());
         }
 
-        $this->primaryKeyFieldsValues[] = $pkValues;
+        $this->primaryKeyFieldsValues[$normPkValues] = true;
 
         return parent::current();
+    }
+
+    private static function normalisePrimaryKeysValue(array $primaryKeyValues): string
+    {
+        return implode(
+            ':',
+            array_map(
+                static function ($value) {
+                    return addcslashes((string) $value, '\:');
+                },
+                $primaryKeyValues
+            )
+        );
     }
 }

--- a/src/Extract/CsvFileExtractor/EnforceUniqueFieldIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforceUniqueFieldIterator.php
@@ -31,11 +31,11 @@ class EnforceUniqueFieldIterator extends IteratorIterator
                 continue;
             }
 
-            if (in_array($value, $this->uniqueFieldValues[$field], false)) {
+            if (isset($this->uniqueFieldValues[$field][$value])) {
                 throw DuplicateFieldValueException::create($field, $value, $this->key());
             }
 
-            $this->uniqueFieldValues[$field][] = $value;
+            $this->uniqueFieldValues[$field][$value] = true;
         }
 
         return parent::current();

--- a/tests/Slurp/Extract/CsvFileExtractor/EnforcePrimaryKeyIteratorTest.php
+++ b/tests/Slurp/Extract/CsvFileExtractor/EnforcePrimaryKeyIteratorTest.php
@@ -45,4 +45,29 @@ class EnforcePrimaryKeyIteratorTest extends TestCase
             // Do nothing
         }
     }
+
+    public function testCannotTrickAFalseUniqueMatchWhenValuesContainNormalisationSeparator(): void
+    {
+        $rows = [
+            ['pk_1' => 'foo', 'pk_2' => 'bar:'],
+            ['pk_1' => 'foo:bar', 'pk_2' => ''],
+        ];
+        $sut = new EnforcePrimaryKeyIterator(
+            new \ArrayIterator($rows),
+            ['pk_1', 'pk_2']
+        );
+        $sut->rewind();
+
+        try {
+            foreach ($sut as $record) {
+                // Do nothing
+            }
+        } catch (\Throwable $e) {
+            self::fail('Enforcement of primary was tricked into a false match.');
+        }
+
+        // Perform an assertion to avoid warning of risky test, and ensure
+        // the test increments the assertion count.
+        self::assertTrue(true);
+    }
 }


### PR DESCRIPTION
**What:** Switches array structure for tracking unique values to be able to use `isset()` rather than `in_array()` for the lookups.
**Why:** `in_array()` becomes very slow with a lot of values.
**Issue:** #50 