### PR TITLE
zbdev-15688 throw ExtractionException when primary key not found

### DIFF
--- a/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MilesAsylum\Slurp\Extract\CsvFileExtractor;
 
 use MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException;
+use MilesAsylum\Slurp\Extract\Exception\ExtractionException;
 
 class EnforcePrimaryKeyIterator extends \IteratorIterator
 {
@@ -29,7 +30,7 @@ class EnforcePrimaryKeyIterator extends \IteratorIterator
 
         foreach ($this->primaryKeyFields as $pkField) {
             if (!array_key_exists($pkField, $currentRecord)) {
-                throw new \InvalidArgumentException('The supplied record does not contain the primary key field ' . $pkField . '.');
+                throw new ExtractionException('The supplied record does not contain the primary key field ' . $pkField . '.');
             }
 
             $pkValues[$pkField] = $currentRecord[$pkField];

--- a/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
+++ b/src/Extract/CsvFileExtractor/EnforcePrimaryKeyIterator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MilesAsylum\Slurp\Extract\CsvFileExtractor;
 
 use MilesAsylum\Slurp\Extract\Exception\DuplicatePrimaryKeyValueException;
-use MilesAsylum\Slurp\Extract\Exception\ExtractionException;
+use MilesAsylum\Slurp\Extract\Exception\MissingPrimaryKeyException;
 
 class EnforcePrimaryKeyIterator extends \IteratorIterator
 {
@@ -30,7 +30,7 @@ class EnforcePrimaryKeyIterator extends \IteratorIterator
 
         foreach ($this->primaryKeyFields as $pkField) {
             if (!array_key_exists($pkField, $currentRecord)) {
-                throw new ExtractionException('The supplied record does not contain the primary key field ' . $pkField . '.');
+                throw new MissingPrimaryKeyException('The supplied record does not contain the primary key field ' . $pkField . '.');
             }
 
             $pkValues[$pkField] = $currentRecord[$pkField];

--- a/src/Extract/Exception/MissingPrimaryKeyException.php
+++ b/src/Extract/Exception/MissingPrimaryKeyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MilesAsylum\Slurp\Extract\Exception;
+
+class MissingPrimaryKeyException extends ExtractionException
+{
+
+}

--- a/src/Extract/Exception/MissingPrimaryKeyException.php
+++ b/src/Extract/Exception/MissingPrimaryKeyException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MilesAsylum\Slurp\Extract\Exception;
 
 class MissingPrimaryKeyException extends ExtractionException

--- a/src/Extract/Exception/MissingPrimaryKeyException.php
+++ b/src/Extract/Exception/MissingPrimaryKeyException.php
@@ -6,5 +6,4 @@ namespace MilesAsylum\Slurp\Extract\Exception;
 
 class MissingPrimaryKeyException extends ExtractionException
 {
-
 }

--- a/src/OuterPipeline/ExtractionStage.php
+++ b/src/OuterPipeline/ExtractionStage.php
@@ -88,10 +88,10 @@ class ExtractionStage extends AbstractOuterStage
                 $previousRecordId = $id;
             }
         } catch (MissingPrimaryKeyException $e) {
-            $this->dispatchExtractionFailedEvent($e, $previousRecordId);
+            $this->dispatchExtractionFailedEvent($e, $previousRecordId + 1);
         } catch (ExtractionException $e) {
             $slurp->abort();
-            $this->dispatchExtractionFailedEvent($e, $previousRecordId);
+            $this->dispatchExtractionFailedEvent($e, $previousRecordId + 1);
         }
 
         $this->dispatch(ExtractionEndedEvent::NAME, new ExtractionEndedEvent());
@@ -99,11 +99,11 @@ class ExtractionStage extends AbstractOuterStage
         return $slurp;
     }
 
-    public function dispatchExtractionFailedEvent(ExtractionException $e, int|null $previousRecordId): void
+    private function dispatchExtractionFailedEvent(ExtractionException $e, int $recordId): void
     {
         $this->dispatch(
             ExtractionFailedEvent::NAME,
-            new ExtractionFailedEvent($e->getMessage(), $previousRecordId + 1)
+            new ExtractionFailedEvent($e->getMessage(), $recordId)
         );
     }
 }


### PR DESCRIPTION
hey @courtney-miles 

I've converted this exception to an `ExtractionException`, which then plays nicely with the console validation feedback

Let me know if we should be providing more info to the operator regarding why the primary key is missing

cheers