### PR TITLE
fix: Replaced call to deprecated league/csv method

### DIFF
--- a/src/SlurpFactory.php
+++ b/src/SlurpFactory.php
@@ -60,7 +60,7 @@ class SlurpFactory
         $uniqueFields = $this->getUniqueFieldNamesFromSchema($schema);
 
         return new CsvFileExtractor(
-            Reader::createFromPath($path),
+            Reader::from($path),
             $primaryKeys,
             $uniqueFields
         );


### PR DESCRIPTION
Update `\MilesAsylum\Slurp\SlurpFactory::createCsvFileExtractor` to call `\League\Csv\Reader::from` instead of `\League\Csv\Reader::createFromPath`